### PR TITLE
Fix python_version format

### DIFF
--- a/microsoftscom.json
+++ b/microsoftscom.json
@@ -19,10 +19,7 @@
     "latest_tested_versions": [
         "On Prem, Version 7.2.11719.0"
     ],
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "app_wizard_version": "1.0.0",
     "configuration": {
         "server_url": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)